### PR TITLE
Cargo features for CUDA version (updated Dec. 10)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
   name: Cargo build
   command: |
     export PATH=/root/.cargo/bin:$PATH
-    cargo build -vv
+    cargo build -vv $CRATE_CARGO_FEATURES
 
 .job_apt_template: &job_apt
   steps:
@@ -35,94 +35,140 @@ jobs:
     docker:
       - image: nvidia/cuda:latest
   9.2-devel-ubuntu18.04:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_9_2
     <<: *job_apt
     docker:
       - image: nvidia/cuda:9.2-devel-ubuntu18.04
   10.0-devel-ubuntu16.04:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_10_0
     <<: *job_apt
     docker:
       - image: nvidia/cuda:10.0-devel-ubuntu16.04
   9.2-devel-ubuntu16.04:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_9_2
     <<: *job_apt
     docker:
       - image: nvidia/cuda:9.2-devel-ubuntu16.04
   9.1-devel-ubuntu16.04:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_9_1
     <<: *job_apt
     docker:
       - image: nvidia/cuda:9.1-devel-ubuntu16.04
   9.0-devel-ubuntu16.04:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_9_0
     <<: *job_apt
     docker:
       - image: nvidia/cuda:9.0-devel-ubuntu16.04
   8.0-devel-ubuntu16.04:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_8_0
     <<: *job_apt
     docker:
       - image: nvidia/cuda:8.0-devel-ubuntu16.04
   8.0-devel-ubuntu14.04:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_8_0
     <<: *job_apt
     docker:
       - image: nvidia/cuda:8.0-devel-ubuntu14.04
   7.5-devel-ubuntu14.04:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_7_5
     <<: *job_apt
     docker:
       - image: nvidia/cuda:7.5-devel-ubuntu14.04
   7.0-devel-ubuntu14.04:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_7_0
     <<: *job_apt
     docker:
       - image: nvidia/cuda:7.0-devel-ubuntu14.04
   6.5-devel-ubuntu14.04:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_6_5
     <<: *job_apt
     docker:
       - image: nvidia/cuda:6.5-devel-ubuntu14.04
   10.0-devel-centos7:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_10_0
     <<: *job_yum
     docker:
       - image: nvidia/cuda:10.0-devel-centos7
   9.2-devel-centos7:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_9_2
     <<: *job_yum
     docker:
       - image: nvidia/cuda:9.2-devel-centos7
   9.1-devel-centos7:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_9_1
     <<: *job_yum
     docker:
       - image: nvidia/cuda:9.1-devel-centos7
   9.0-devel-centos7:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_9_0
     <<: *job_yum
     docker:
       - image: nvidia/cuda:9.0-devel-centos7
   8.0-devel-centos7:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_8_0
     <<: *job_yum
     docker:
       - image: nvidia/cuda:8.0-devel-centos7
   7.5-devel-centos7:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_7_5
     <<: *job_yum
     docker:
       - image: nvidia/cuda:7.5-devel-centos7
   7.0-devel-centos7:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_7_0
     <<: *job_yum
     docker:
       - image: nvidia/cuda:7.0-devel-centos7
   10.0-devel-centos6:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_10_0
     <<: *job_yum
     docker:
       - image: nvidia/cuda:10.0-devel-centos6
   9.2-devel-centos6:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_9_2
     <<: *job_yum
     docker:
       - image: nvidia/cuda:9.2-devel-centos6
   9.1-devel-centos6:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_9_1
     <<: *job_yum
     docker:
       - image: nvidia/cuda:9.1-devel-centos6
   9.0-devel-centos6:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_9_0
     <<: *job_yum
     docker:
       - image: nvidia/cuda:9.0-devel-centos6
   8.0-devel-centos6:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_8_0
     <<: *job_yum
     docker:
       - image: nvidia/cuda:8.0-devel-centos6
   7.5-devel-centos6:
+    environment:
+      CRATE_CARGO_FEATURES: --no-default-features --features cuda_7_5
     <<: *job_yum
     docker:
       - image: nvidia/cuda:7.5-devel-centos6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,24 @@ keywords      = ["GPGPU", "CUDA", "ffi"]
 license       = "MIT"
 readme        = "README.md"
 categories    = []
+
+[features]
+default       = ["cuda_8_0"]
+cuda_6_5      = []
+cuda_7_0      = ["gte_cuda_7_0"]
+cuda_7_5      = ["gte_cuda_7_0", "gte_cuda_7_5"]
+cuda_8_0      = ["gte_cuda_7_0", "gte_cuda_7_5", "gte_cuda_8_0"]
+cuda_9_0      = ["gte_cuda_7_0", "gte_cuda_7_5", "gte_cuda_8_0", "gte_cuda_9_0"]
+cuda_9_1      = ["gte_cuda_7_0", "gte_cuda_7_5", "gte_cuda_8_0", "gte_cuda_9_0", "gte_cuda_9_1"]
+cuda_9_2      = ["gte_cuda_7_0", "gte_cuda_7_5", "gte_cuda_8_0", "gte_cuda_9_0", "gte_cuda_9_1", "gte_cuda_9_2"]
+cuda_10_0     = ["gte_cuda_7_0", "gte_cuda_7_5", "gte_cuda_8_0", "gte_cuda_9_0", "gte_cuda_9_1", "gte_cuda_9_2", "gte_cuda_10_0"]
+gte_cuda_7_0  = []
+gte_cuda_7_5  = []
+gte_cuda_8_0  = []
+gte_cuda_9_0  = []
+gte_cuda_9_1  = []
+gte_cuda_9_2  = []
+gte_cuda_10_0 = []
+
+[dependencies]
+static_assertions = "0.3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,16 @@
+#[macro_use] extern crate static_assertions;
+
 pub mod cublas;
 pub mod cuda;
 pub mod cudart;
+#[cfg(feature = "gte_cuda_8_0")]
+pub mod cuda_fp16;
 pub mod vector_types;
+
+#[cfg(feature = "cuda_8_0")]
+const_assert_eq!(cuda_8_0_api_version;  cuda::__CUDA_API_VERSION, 8000);
+#[cfg(feature = "cuda_8_0")]
+const_assert_eq!(cuda_8_0_version;      cuda::CUDA_VERSION,       8000);
 
 #[test]
 fn cuda_version() {


### PR DESCRIPTION
This commit adds feature flags in Cargo.toml for specific installed versions of the CUDA toolkit. The design is basically the same as that used by clang-sys (https://github.com/KyleMayes/clang-sys/blob/master/Cargo.toml).

Edit (Dec. 10): Assuming the current static bindings for CUDA 8.0, I added static API version checks (using the `static_assertions` crate) and conditional bindings to the FP16 API (currently just an empty module). This way in which the version features are used should be independent of whether static or dynamic bindings are used in cuda-sys.

I also set the corresponding cargo features for each nvidia docker image in the CircleCI config. (Because cuda-sys has static bindings to CUDA 8.0, I set the default feature to be "cuda_8_0" in Cargo.toml, but also set --no-default-features in the CI runs.)

These feature flags are not currently used by the library or build script yet to actually select the CUDA version (e.g. for dynamic linking), but that could be done in another PR (pending discussion in #4).