### PR TITLE
Add rerun-if-env-changed to build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,4 +19,5 @@ fn main() {
     println!("cargo:rustc-link-lib=dylib=cudart");
     println!("cargo:rustc-link-lib=dylib=cublas");
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-env-changed=CUDA_LIBRARY_PATH");
 }


### PR DESCRIPTION
Currently, if you set `CUDA_LIBRARY_PATH` a wrong path and fail to run `cargo build` in a crate using `cargo-sys`, then you should run `cargo clean` before rebuilding. By adding `rerun-if-env-changed=CUDA_LIBRARY_PATH` to build.rs, it becomes unnecessary.

See here: https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script