### PR TITLE
Add Default CUDA path list for Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ version: 2
   name: Cargo build
   command: |
     export PATH=/root/.cargo/bin:$PATH
+    export LD_LIBRARY_PATH="/usr/local/cuda/compat"
     cargo test -v
 
 .job_apt_template: &job_apt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,158 +1,21 @@
 version: 2
 
 .cargo: &cargo
-  name: Cargo build
-  command: |
-    export PATH=/root/.cargo/bin:$PATH
-    export LD_LIBRARY_PATH="/usr/local/cuda/compat"
-    cargo test -v
-
-.job_apt_template: &job_apt
   steps:
     - checkout
     - run:
-        name: Install Rust
+        name: Cargo test
         command: |
-          apt update
-          apt install -y curl
-          curl https://sh.rustup.rs -sSf | sh -s -- -y
-    - run:
-        <<: *cargo
-
-.job_yum_template: &job_yum
-  steps:
-    - checkout
-    - run:
-        name: Install Rust
-        command: |
-          yum install -y curl
-          curl https://sh.rustup.rs -sSf | sh -s -- -y
-    - run:
-        <<: *cargo
+          cargo test -vv
 
 jobs:
-  latest:
-    <<: *job_apt
+  cuda10.0-ubuntu18.04:
+    <<: *cargo
     docker:
-      - image: nvidia/cuda:latest
-  9.2-devel-ubuntu18.04:
-    <<: *job_apt
-    docker:
-      - image: nvidia/cuda:9.2-devel-ubuntu18.04
-  10.0-devel-ubuntu16.04:
-    <<: *job_apt
-    docker:
-      - image: nvidia/cuda:10.0-devel-ubuntu16.04
-  9.2-devel-ubuntu16.04:
-    <<: *job_apt
-    docker:
-      - image: nvidia/cuda:9.2-devel-ubuntu16.04
-  9.1-devel-ubuntu16.04:
-    <<: *job_apt
-    docker:
-      - image: nvidia/cuda:9.1-devel-ubuntu16.04
-  9.0-devel-ubuntu16.04:
-    <<: *job_apt
-    docker:
-      - image: nvidia/cuda:9.0-devel-ubuntu16.04
-  8.0-devel-ubuntu16.04:
-    <<: *job_apt
-    docker:
-      - image: nvidia/cuda:8.0-devel-ubuntu16.04
-  8.0-devel-ubuntu14.04:
-    <<: *job_apt
-    docker:
-      - image: nvidia/cuda:8.0-devel-ubuntu14.04
-  7.5-devel-ubuntu14.04:
-    <<: *job_apt
-    docker:
-      - image: nvidia/cuda:7.5-devel-ubuntu14.04
-  7.0-devel-ubuntu14.04:
-    <<: *job_apt
-    docker:
-      - image: nvidia/cuda:7.0-devel-ubuntu14.04
-  6.5-devel-ubuntu14.04:
-    <<: *job_apt
-    docker:
-      - image: nvidia/cuda:6.5-devel-ubuntu14.04
-  10.0-devel-centos7:
-    <<: *job_yum
-    docker:
-      - image: nvidia/cuda:10.0-devel-centos7
-  9.2-devel-centos7:
-    <<: *job_yum
-    docker:
-      - image: nvidia/cuda:9.2-devel-centos7
-  9.1-devel-centos7:
-    <<: *job_yum
-    docker:
-      - image: nvidia/cuda:9.1-devel-centos7
-  9.0-devel-centos7:
-    <<: *job_yum
-    docker:
-      - image: nvidia/cuda:9.0-devel-centos7
-  8.0-devel-centos7:
-    <<: *job_yum
-    docker:
-      - image: nvidia/cuda:8.0-devel-centos7
-  7.5-devel-centos7:
-    <<: *job_yum
-    docker:
-      - image: nvidia/cuda:7.5-devel-centos7
-  7.0-devel-centos7:
-    <<: *job_yum
-    docker:
-      - image: nvidia/cuda:7.0-devel-centos7
-  10.0-devel-centos6:
-    <<: *job_yum
-    docker:
-      - image: nvidia/cuda:10.0-devel-centos6
-  9.2-devel-centos6:
-    <<: *job_yum
-    docker:
-      - image: nvidia/cuda:9.2-devel-centos6
-  9.1-devel-centos6:
-    <<: *job_yum
-    docker:
-      - image: nvidia/cuda:9.1-devel-centos6
-  9.0-devel-centos6:
-    <<: *job_yum
-    docker:
-      - image: nvidia/cuda:9.0-devel-centos6
-  8.0-devel-centos6:
-    <<: *job_yum
-    docker:
-      - image: nvidia/cuda:8.0-devel-centos6
-  7.5-devel-centos6:
-    <<: *job_yum
-    docker:
-      - image: nvidia/cuda:7.5-devel-centos6
+      - image: registry.gitlab.com/rust-cuda/container:cuda10.0-ubuntu18.04
 
 workflows:
   version: 2
   tests:
     jobs:
-      - latest
-      - 9.2-devel-ubuntu18.04
-      - 10.0-devel-ubuntu16.04
-      - 9.2-devel-ubuntu16.04
-      - 9.1-devel-ubuntu16.04
-      - 9.0-devel-ubuntu16.04
-      - 8.0-devel-ubuntu16.04
-      - 8.0-devel-ubuntu14.04
-      - 7.5-devel-ubuntu14.04
-      - 7.0-devel-ubuntu14.04
-      - 6.5-devel-ubuntu14.04
-      - 10.0-devel-centos7
-      - 9.2-devel-centos7
-      - 9.1-devel-centos7
-      - 9.0-devel-centos7
-      - 8.0-devel-centos7
-      - 7.5-devel-centos7
-      - 7.0-devel-centos7
-      - 10.0-devel-centos6
-      - 9.2-devel-centos6
-      - 9.1-devel-centos6
-      - 9.0-devel-centos6
-      - 8.0-devel-centos6
-      - 7.5-devel-centos6
+      - cuda10.0-ubuntu18.04

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,7 @@ version: 2
   name: Cargo build
   command: |
     export PATH=/root/.cargo/bin:$PATH
-    export LD_LIBRARY_PATH="/usr/local/cuda/compat"
-    cargo test -v
+    cargo build -v
 
 .job_apt_template: &job_apt
   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,158 @@
 version: 2
 
 .cargo: &cargo
+  name: Cargo build
+  command: |
+    export PATH=/root/.cargo/bin:$PATH
+    export LD_LIBRARY_PATH="/usr/local/cuda/compat"
+    cargo test -v
+
+.job_apt_template: &job_apt
   steps:
     - checkout
     - run:
-        name: Cargo test
+        name: Install Rust
         command: |
-          cargo test -vv
+          apt update
+          apt install -y curl
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+    - run:
+        <<: *cargo
+
+.job_yum_template: &job_yum
+  steps:
+    - checkout
+    - run:
+        name: Install Rust
+        command: |
+          yum install -y curl
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+    - run:
+        <<: *cargo
 
 jobs:
-  cuda10.0-ubuntu18.04:
-    <<: *cargo
+  latest:
+    <<: *job_apt
     docker:
-      - image: registry.gitlab.com/rust-cuda/container:cuda10.0-ubuntu18.04
+      - image: nvidia/cuda:latest
+  9.2-devel-ubuntu18.04:
+    <<: *job_apt
+    docker:
+      - image: nvidia/cuda:9.2-devel-ubuntu18.04
+  10.0-devel-ubuntu16.04:
+    <<: *job_apt
+    docker:
+      - image: nvidia/cuda:10.0-devel-ubuntu16.04
+  9.2-devel-ubuntu16.04:
+    <<: *job_apt
+    docker:
+      - image: nvidia/cuda:9.2-devel-ubuntu16.04
+  9.1-devel-ubuntu16.04:
+    <<: *job_apt
+    docker:
+      - image: nvidia/cuda:9.1-devel-ubuntu16.04
+  9.0-devel-ubuntu16.04:
+    <<: *job_apt
+    docker:
+      - image: nvidia/cuda:9.0-devel-ubuntu16.04
+  8.0-devel-ubuntu16.04:
+    <<: *job_apt
+    docker:
+      - image: nvidia/cuda:8.0-devel-ubuntu16.04
+  8.0-devel-ubuntu14.04:
+    <<: *job_apt
+    docker:
+      - image: nvidia/cuda:8.0-devel-ubuntu14.04
+  7.5-devel-ubuntu14.04:
+    <<: *job_apt
+    docker:
+      - image: nvidia/cuda:7.5-devel-ubuntu14.04
+  7.0-devel-ubuntu14.04:
+    <<: *job_apt
+    docker:
+      - image: nvidia/cuda:7.0-devel-ubuntu14.04
+  6.5-devel-ubuntu14.04:
+    <<: *job_apt
+    docker:
+      - image: nvidia/cuda:6.5-devel-ubuntu14.04
+  10.0-devel-centos7:
+    <<: *job_yum
+    docker:
+      - image: nvidia/cuda:10.0-devel-centos7
+  9.2-devel-centos7:
+    <<: *job_yum
+    docker:
+      - image: nvidia/cuda:9.2-devel-centos7
+  9.1-devel-centos7:
+    <<: *job_yum
+    docker:
+      - image: nvidia/cuda:9.1-devel-centos7
+  9.0-devel-centos7:
+    <<: *job_yum
+    docker:
+      - image: nvidia/cuda:9.0-devel-centos7
+  8.0-devel-centos7:
+    <<: *job_yum
+    docker:
+      - image: nvidia/cuda:8.0-devel-centos7
+  7.5-devel-centos7:
+    <<: *job_yum
+    docker:
+      - image: nvidia/cuda:7.5-devel-centos7
+  7.0-devel-centos7:
+    <<: *job_yum
+    docker:
+      - image: nvidia/cuda:7.0-devel-centos7
+  10.0-devel-centos6:
+    <<: *job_yum
+    docker:
+      - image: nvidia/cuda:10.0-devel-centos6
+  9.2-devel-centos6:
+    <<: *job_yum
+    docker:
+      - image: nvidia/cuda:9.2-devel-centos6
+  9.1-devel-centos6:
+    <<: *job_yum
+    docker:
+      - image: nvidia/cuda:9.1-devel-centos6
+  9.0-devel-centos6:
+    <<: *job_yum
+    docker:
+      - image: nvidia/cuda:9.0-devel-centos6
+  8.0-devel-centos6:
+    <<: *job_yum
+    docker:
+      - image: nvidia/cuda:8.0-devel-centos6
+  7.5-devel-centos6:
+    <<: *job_yum
+    docker:
+      - image: nvidia/cuda:7.5-devel-centos6
 
 workflows:
   version: 2
   tests:
     jobs:
-      - cuda10.0-ubuntu18.04
+      - latest
+      - 9.2-devel-ubuntu18.04
+      - 10.0-devel-ubuntu16.04
+      - 9.2-devel-ubuntu16.04
+      - 9.1-devel-ubuntu16.04
+      - 9.0-devel-ubuntu16.04
+      - 8.0-devel-ubuntu16.04
+      - 8.0-devel-ubuntu14.04
+      - 7.5-devel-ubuntu14.04
+      - 7.0-devel-ubuntu14.04
+      - 6.5-devel-ubuntu14.04
+      - 10.0-devel-centos7
+      - 9.2-devel-centos7
+      - 9.1-devel-centos7
+      - 9.0-devel-centos7
+      - 8.0-devel-centos7
+      - 7.5-devel-centos7
+      - 7.0-devel-centos7
+      - 10.0-devel-centos6
+      - 9.2-devel-centos6
+      - 9.1-devel-centos6
+      - 9.0-devel-centos6
+      - 8.0-devel-centos6
+      - 7.5-devel-centos6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
   name: Cargo build
   command: |
     export PATH=/root/.cargo/bin:$PATH
-    cargo build -vv
+    cargo test -v
 
 .job_apt_template: &job_apt
   steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ keywords      = ["GPGPU", "CUDA", "ffi"]
 license       = "MIT"
 readme        = "README.md"
 categories    = []
+
+[build-dependencies]
+glob = "*"

--- a/build.rs
+++ b/build.rs
@@ -35,6 +35,13 @@ fn find_cuda() -> Vec<PathBuf> {
             valid_paths.push(lib.clone());
             valid_paths.push(lib.join("stubs"));
         }
+        let base = base.join("targets/x86_64-linux");
+        let header = base.join("include/cuda.h");
+        if header.is_file() {
+            valid_paths.push(base.join("lib"));
+            valid_paths.push(base.join("lib/stubs"));
+            continue;
+        }
     }
     eprintln!("Found CUDA paths: {:?}", valid_paths);
     valid_paths
@@ -112,9 +119,9 @@ fn main() {
             println!("cargo:rustc-link-search=native={}", path.display());
         }
     };
+    println!("cargo:rustc-link-lib=dylib=cuda");
     println!("cargo:rustc-link-lib=dylib=cudart");
     println!("cargo:rustc-link-lib=dylib=cublas");
-    println!("cargo:rustc-link-lib=dylib=cuda");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=CUDA_LIBRARY_PATH");
 }

--- a/build.rs
+++ b/build.rs
@@ -27,7 +27,7 @@ fn find_cuda() -> Vec<PathBuf> {
         let path = base.join("include/cuda.h");
         if path.is_file() {
             valid_paths.push(base.join("lib64"));
-            valid_paths.push(base.join("lib64/stubs"));
+            valid_paths.push(base.join("compat"));
         }
     }
     valid_paths

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,6 @@
+extern crate glob;
+
+use glob::glob;
 use std::{env, path::PathBuf};
 
 fn read_env() -> Vec<PathBuf> {
@@ -17,10 +20,14 @@ fn read_env() -> Vec<PathBuf> {
 
 fn find_cuda() -> Vec<PathBuf> {
     let mut candidates = read_env();
-    candidates.push(PathBuf::from("/usr/local/cuda"));
     candidates.push(PathBuf::from("/opt/cuda"));
+    candidates.push(PathBuf::from("/usr/local/cuda"));
+    for e in glob("/usr/local/cuda-*").unwrap() {
+        if let Ok(path) = e {
+            candidates.push(path)
+        }
+    }
 
-    // CUDA directory must have include/cuda.h header file
     let mut valid_paths = vec![];
     for base in &candidates {
         let lib = PathBuf::from(base).join("lib64");

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,6 @@
-use std::env;
+use std::{env, path::PathBuf};
 
-fn find_library_paths() -> Vec<String> {
+fn read_env() -> Vec<PathBuf> {
     if let Ok(path) = env::var("CUDA_LIBRARY_PATH") {
         // The location of the libcuda, libcudart, and libcublas can be hardcoded with the
         // CUDA_LIBRARY_PATH environment variable.
@@ -9,81 +9,96 @@ fn find_library_paths() -> Vec<String> {
         } else {
             ":"
         };
+        path.split(split_char).map(|s| PathBuf::from(s)).collect()
+    } else {
+        vec![]
+    }
+}
 
-        return path.split(split_char).map(|s| s.to_owned()).collect();
+fn find_cuda() -> PathBuf {
+    let mut candidates = read_env();
+    candidates.push(PathBuf::from("/usr/local/cuda"));
+    candidates.push(PathBuf::from("/opt/cuda"));
+
+    // CUDA directory must have include/cuda.h header file
+    for base in &candidates {
+        let base = PathBuf::from(base);
+        let path = base.join("include/cuda.h");
+        if path.is_file() {
+            return base.join("lib64");
+        }
+    }
+    panic!("CUDA cannot find");
+}
+
+fn find_cuda_windows() -> PathBuf {
+    let paths = read_env();
+    if !paths.is_empty() {
+        return paths[0].clone();
     }
 
-    if cfg!(target_os = "windows") {
-        if let Ok(path) = env::var("CUDA_PATH") {
-            // If CUDA_LIBRARY_PATH is not found, then CUDA_PATH will be used when building for
-            // Windows to locate the Cuda installation. Cuda installs the full Cuda SDK for 64-bit,
-            // but only a limited set of libraries for 32-bit. Namely, it does not include cublas in
-            // 32-bit, which cuda-sys requires.
+    if let Ok(path) = env::var("CUDA_PATH") {
+        // If CUDA_LIBRARY_PATH is not found, then CUDA_PATH will be used when building for
+        // Windows to locate the Cuda installation. Cuda installs the full Cuda SDK for 64-bit,
+        // but only a limited set of libraries for 32-bit. Namely, it does not include cublas in
+        // 32-bit, which cuda-sys requires.
 
-            // 'path' points to the base of the CUDA Installation. The lib directory is a
-            // sub-directory.
-            let path = std::path::Path::new(&path);
+        // 'path' points to the base of the CUDA Installation. The lib directory is a
+        // sub-directory.
+        let path = PathBuf::from(path);
 
-            // To do this the right way, we check to see which target we're building for.
-            let target = env::var("TARGET")
-                .expect("cargo did not set the TARGET environment variable as required.");
+        // To do this the right way, we check to see which target we're building for.
+        let target = env::var("TARGET")
+            .expect("cargo did not set the TARGET environment variable as required.");
 
-            // Targets use '-' separators. e.g. x86_64-pc-windows-msvc
-            let target_components: Vec<_> = target.as_str().split("-").collect();
+        // Targets use '-' separators. e.g. x86_64-pc-windows-msvc
+        let target_components: Vec<_> = target.as_str().split("-").collect();
 
-            // We check that we're building for Windows. This code assumes that the layout in
-            // CUDA_PATH matches Windows.
-            if target_components[2] != "windows" {
-                println!(
-                    "INFO: The CUDA_PATH variable is only used by cuda-sys on Windows. Your target \
-                     is {}.",
-                    target
-                );
-                return vec![];
-            }
-
-            // Sanity check that the second component of 'target' is "pc"
-            debug_assert_eq!(
-                "pc", target_components[1],
-                "Expected a Windows target to have the second component be 'pc'. Target: {}",
+        // We check that we're building for Windows. This code assumes that the layout in
+        // CUDA_PATH matches Windows.
+        if target_components[2] != "windows" {
+            panic!(
+                "The CUDA_PATH variable is only used by cuda-sys on Windows. Your target is {}.",
                 target
             );
-
-            // x86_64 should use the libs in the "lib/x64" directory. If we ever support i686 (which
-            // does not ship with cublas support), its libraries are in "lib/Win32".
-            let lib_path = match target_components[0] {
-                "x86_64" => "x64",
-                "i686" => {
-                    // lib path would be "Win32" if we support i686. "cublas" is not present in the
-                    // 32-bit install.
-                    println!("INFO: Rust cuda-sys does not currently support 32-bit Windows.");
-                    return vec![];
-                }
-                _ => {
-                    println!("INFO: Rust cuda-sys only supports the x86_64 Windows architecture.");
-                    return vec![];
-                }
-            };
-
-            return vec![
-                // i.e. $CUDA_PATH/lib/x64
-                path.join("lib")
-                    .join(lib_path)
-                    .to_str()
-                    .unwrap()
-                    .to_string(),
-            ];
         }
+
+        // Sanity check that the second component of 'target' is "pc"
+        debug_assert_eq!(
+            "pc", target_components[1],
+            "Expected a Windows target to have the second component be 'pc'. Target: {}",
+            target
+        );
+
+        // x86_64 should use the libs in the "lib/x64" directory. If we ever support i686 (which
+        // does not ship with cublas support), its libraries are in "lib/Win32".
+        let lib_path = match target_components[0] {
+            "x86_64" => "x64",
+            "i686" => {
+                // lib path would be "Win32" if we support i686. "cublas" is not present in the
+                // 32-bit install.
+                panic!("Rust cuda-sys does not currently support 32-bit Windows.");
+            }
+            _ => {
+                panic!("Rust cuda-sys only supports the x86_64 Windows architecture.");
+            }
+        };
+
+        // i.e. $CUDA_PATH/lib/x64
+        return path.join("lib").join(lib_path);
     }
 
     // No idea where to look for CUDA
-    vec![]
+    panic!("CUDA cannot find");
 }
 
 fn main() {
-    for p in find_library_paths() {
-        println!("cargo:rustc-link-search=native={}", p);
-    }
+    let path = if cfg!(target_os = "windows") {
+        find_cuda_windows()
+    } else {
+        find_cuda()
+    };
+    println!("cargo:rustc-link-search=native={}", path.display());
     println!("cargo:rustc-link-lib=dylib=cuda");
     println!("cargo:rustc-link-lib=dylib=cudart");
     println!("cargo:rustc-link-lib=dylib=cublas");

--- a/build.rs
+++ b/build.rs
@@ -23,12 +23,10 @@ fn find_cuda() -> Vec<PathBuf> {
     // CUDA directory must have include/cuda.h header file
     let mut valid_paths = vec![];
     for base in &candidates {
-        let base = PathBuf::from(base);
-        let header = base.join("include/cuda.h");
-        if header.is_file() {
-            valid_paths.push(base.join("lib64"));
-            valid_paths.push(base.join("lib64/stubs"));
-            continue;
+        let lib = PathBuf::from(base).join("lib64");
+        if lib.is_dir() {
+            valid_paths.push(lib.clone());
+            valid_paths.push(lib.join("stubs"));
         }
     }
     eprintln!("Found CUDA paths: {:?}", valid_paths);

--- a/build.rs
+++ b/build.rs
@@ -24,12 +24,21 @@ fn find_cuda() -> Vec<PathBuf> {
     let mut valid_paths = vec![];
     for base in &candidates {
         let base = PathBuf::from(base);
-        let path = base.join("include/cuda.h");
-        if path.is_file() {
+        let header = base.join("include/cuda.h");
+        if header.is_file() {
             valid_paths.push(base.join("lib64"));
-            valid_paths.push(base.join("compat"));
+            valid_paths.push(base.join("lib64/stubs"));
+            continue;
+        }
+        let base = base.join("targets/x86_64-linux");
+        let header = base.join("include/cuda.h");
+        if header.is_file() {
+            valid_paths.push(base.join("lib"));
+            valid_paths.push(base.join("lib/stubs"));
+            continue;
         }
     }
+    eprintln!("Found CUDA paths: {:?}", valid_paths);
     valid_paths
 }
 

--- a/build.rs
+++ b/build.rs
@@ -30,13 +30,6 @@ fn find_cuda() -> Vec<PathBuf> {
             valid_paths.push(base.join("lib64/stubs"));
             continue;
         }
-        let base = base.join("targets/x86_64-linux");
-        let header = base.join("include/cuda.h");
-        if header.is_file() {
-            valid_paths.push(base.join("lib"));
-            valid_paths.push(base.join("lib/stubs"));
-            continue;
-        }
     }
     eprintln!("Found CUDA paths: {:?}", valid_paths);
     valid_paths
@@ -114,9 +107,9 @@ fn main() {
             println!("cargo:rustc-link-search=native={}", path.display());
         }
     };
-    println!("cargo:rustc-link-lib=dylib=cuda");
     println!("cargo:rustc-link-lib=dylib=cudart");
     println!("cargo:rustc-link-lib=dylib=cublas");
+    println!("cargo:rustc-link-lib=dylib=cuda");
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=CUDA_LIBRARY_PATH");
 }


### PR DESCRIPTION
Split from #4

Default PATHs
-------------------
- /opt/cuda (ArchLinux)
- /usr/local/cuda (nvidia/cuda container image)
- /usr/local/cuda-* (manual install to ubuntu18.04)